### PR TITLE
Implement close method, add `with DelcomMultiColorIndicator() as __` …

### DIFF
--- a/.github/workflows/lint_and_package.yml
+++ b/.github/workflows/lint_and_package.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         cache: 'pip'
 
     - name: Install CI Dependencies

--- a/README.md
+++ b/README.md
@@ -35,13 +35,26 @@ Installation
         --reset           Resets the device.
 
 
-Python Code Example
+Python Code Examples
 -------------------
+
 
 ```python
 import delcom904x
+
 light = delcom904x.DelcomMultiColorIndicator()
 light.set_color(delcom904x.red, flashing=True)
+light.close()
+```
+
+```python
+import delcom904x
+
+with delcom904x.DelcomMultiColorIndicator() as light:
+    light.info()
+    color = delcom904x.green
+    light.set_color(color, flashing=True)
+    light.set_intensity(80, color)
 ```
 
 

--- a/delcom904x/__init__.py
+++ b/delcom904x/__init__.py
@@ -14,6 +14,7 @@ product_id = 0xB080
 green = 1
 red = 2
 blue = 4
+yellow = 4
 
 
 def list():

--- a/delcom904x/__init__.py
+++ b/delcom904x/__init__.py
@@ -48,6 +48,16 @@ class DelcomMultiColorIndicator:
             print(f"Failed: {e}")
             raise
 
+    def close(self):
+        """Close the USB connection gracefully"""
+        self.h.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.close()
+
     def info(self):
         """Prints out all the USB, firmware and current configuration
         on the attached multi-color indicator."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
   "black==23.7.*",
   "build==0.10.*",
   "ruff",
-  "twine==4.0.*",
+  "twine==5.1.*",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "delcom904x"
-version = "0.4.0"
+version = "0.5.0"
 description = "A python module to control Delcom USBLMP Products 904x multi-color, USB, visual signal indicators"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
…support

Allow gracefully closing the underlying HID connection  

Allow using more pythonic syntax:  
```
with delcom904x.DelcomMultiColorIndicator() as dmci:
  dmci.info()
  dmci.set_color(delcom904x.red)
```